### PR TITLE
Default attachment charset to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project attempts to follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased Changes
+
+### Added
+
+* Created helper function on `Attachment` to get the RFC content type header.
+
+### Changed
+
+* Allowed null charset on attachments and changed the default to null.
+
 ## 0.5.0 - 2018-02-25
 
 ### Added
@@ -15,7 +25,7 @@ and this project attempts to follow [Semantic Versioning](http://semver.org/spec
 * Add embedded (inline) attachments to emails.
 * Added fluent `addText` and `addHtml` methods on `SimpleContent`
 
-### Change
+### Changed
 
 * Now using `Message` objects instead of string for `SimpleContent`'s text and HTML properties.
 

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -89,7 +89,8 @@ interface Attachment
      * Get a common representation of the RFC 822 formatted Content Type headers, including:
      *  - content type
      *  - name
-     *  - character set
+     *  - character set.
+     *
      * @return string
      */
     public function getRfc2822ContentType(): string;

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -40,9 +40,9 @@ interface Attachment
     /**
      * Get the character set defined on the attachment.
      *
-     * @return string
+     * @return string|null
      */
-    public function getCharset(): string;
+    public function getCharset(): ?string;
 
     /**
      * Set the character set for the attachment.
@@ -84,6 +84,15 @@ interface Attachment
      * @return Attachment
      */
     public function setName(string $name): Attachment;
+
+    /**
+     * Get a common representation of the RFC 822 formatted Content Type headers, including:
+     *  - content type
+     *  - name
+     *  - character set
+     * @return string
+     */
+    public function getRfc2822ContentType(): string;
 
     /**
      * Must be implemented to support comparison.

--- a/src/Attachment/AttachmentWithHeaders.php
+++ b/src/Attachment/AttachmentWithHeaders.php
@@ -8,15 +8,13 @@ use PhpEmail\Attachment;
 
 abstract class AttachmentWithHeaders implements Attachment
 {
-    public const DEFAULT_CHARSET = 'utf-8';
-
     /**
      * @var string|null
      */
     protected $contentType;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $charset;
 
@@ -64,7 +62,7 @@ abstract class AttachmentWithHeaders implements Attachment
     /**
      * {@inheritdoc}
      */
-    public function getCharset(): string
+    public function getCharset(): ?string
     {
         return $this->charset;
     }
@@ -113,5 +111,22 @@ abstract class AttachmentWithHeaders implements Attachment
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRfc2822ContentType(): string
+    {
+        $parts = [
+            $this->getContentType(),
+            sprintf('name="%s"', $this->getName()),
+        ];
+
+        if ($this->getCharset() !== null) {
+            $parts[] = sprintf('charset="%s"', $this->getCharset());
+        }
+
+        return implode('; ', $parts);
     }
 }

--- a/src/Attachment/FileAttachment.php
+++ b/src/Attachment/FileAttachment.php
@@ -24,14 +24,14 @@ class FileAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the file path.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      */
     public function __construct(
         string $file,
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ) {
         Validate::that()
             ->isFile('file', $file)
@@ -51,7 +51,7 @@ class FileAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the file path.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      *
      * @return FileAttachment
      */
@@ -60,7 +60,7 @@ class FileAttachment extends AttachmentWithHeaders
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ): FileAttachment {
         return new self($file, $name, $contentId, $contentType, $charset);
     }

--- a/src/Attachment/ResourceAttachment.php
+++ b/src/Attachment/ResourceAttachment.php
@@ -24,14 +24,14 @@ class ResourceAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the resource.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      */
     public function __construct(
         $resource,
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ) {
         Validate::that()
             ->isStream('resource', $resource)
@@ -51,7 +51,7 @@ class ResourceAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the resource.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      *
      * @return ResourceAttachment
      */
@@ -60,7 +60,7 @@ class ResourceAttachment extends AttachmentWithHeaders
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ): ResourceAttachment {
         return new self($resource, $name, $contentId, $contentType, $charset);
     }

--- a/src/Attachment/UrlAttachment.php
+++ b/src/Attachment/UrlAttachment.php
@@ -27,14 +27,14 @@ class UrlAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the URL.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      */
     public function __construct(
         string $url,
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ) {
         Validate::that()
             ->isUrl('url', $url)
@@ -54,7 +54,7 @@ class UrlAttachment extends AttachmentWithHeaders
      * @param null|string $name        If null, the class will determine a name for the attachment based on the URL.
      * @param null|string $contentId
      * @param null|string $contentType
-     * @param string      $charset
+     * @param null|string $charset
      *
      * @return UrlAttachment
      */
@@ -63,7 +63,7 @@ class UrlAttachment extends AttachmentWithHeaders
         ?string $name = null,
         ?string $contentId = null,
         ?string $contentType = null,
-        string $charset = self::DEFAULT_CHARSET
+        string $charset = null
     ): UrlAttachment {
         return new self($url, $name, $contentId, $contentType, $charset);
     }

--- a/src/Email.php
+++ b/src/Email.php
@@ -365,7 +365,7 @@ class Email
     }
 
     /**
-     * @return array
+     * @return Attachment[]
      */
     public function getEmbedded(): array
     {

--- a/tests/Attachment/FileAttachmentTest.php
+++ b/tests/Attachment/FileAttachmentTest.php
@@ -40,12 +40,13 @@ class FileAttachmentTest extends TestCase
         $attachment = new FileAttachment(self::$file);
 
         self::assertEquals('text/plain', $attachment->getContentType());
-        self::assertEquals('utf-8', $attachment->getCharset());
+        self::assertEquals(null, $attachment->getCharset());
         self::assertEquals(null, $attachment->getContentId());
         self::assertEquals('QXR0YWNobWVudCBmaWxl', $attachment->getBase64Content());
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('attachment_test.txt', $attachment->getName());
         self::assertEquals('/tmp/attachment_test.txt', $attachment->getFile());
+        self::assertEquals('text/plain; name="attachment_test.txt"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"file":"\/tmp\/attachment_test.txt","name":"attachment_test.txt","contentId":null}',
             $attachment->__toString()
@@ -55,7 +56,7 @@ class FileAttachmentTest extends TestCase
     /**
      * @testdox It should create an attachment using a file on the disk and set its headers.
      */
-    public function handlesLocalFileWithHeaders()
+    public function testHandlesLocalFileWithHeaders()
     {
         $attachment = FileAttachment::fromFile(self::$file)
             ->setContentType('text/json')
@@ -70,6 +71,7 @@ class FileAttachmentTest extends TestCase
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('testfile.txt', $attachment->getName());
         self::assertEquals('/tmp/attachment_test.txt', $attachment->getFile());
+        self::assertEquals('text/json; name="testfile.txt"; charset="utf-16"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"file":"\/tmp\/attachment_test.txt","name":"testfile.txt","contentId":"testid"}',
             $attachment->__toString()

--- a/tests/Attachment/ResourceAttachmentTest.php
+++ b/tests/Attachment/ResourceAttachmentTest.php
@@ -58,13 +58,15 @@ class ResourceAttachmentTest extends TestCase
 
         $attachment = new ResourceAttachment($this->resource);
 
+
         self::assertEquals('text/plain', $attachment->getContentType());
-        self::assertEquals('utf-8', $attachment->getCharset());
+        self::assertEquals(null, $attachment->getCharset());
         self::assertEquals(null, $attachment->getContentId());
         self::assertEquals('QXR0YWNobWVudCBmaWxl', $attachment->getBase64Content());
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('attachment test.txt', $attachment->getName());
         self::assertEquals($this->resource, $attachment->getResource());
+        self::assertEquals('text/plain; name="attachment test.txt"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"uri":"\/tmp\/attachment test.txt","name":"attachment test.txt","contentId":null}',
             $attachment->__toString()
@@ -91,6 +93,7 @@ class ResourceAttachmentTest extends TestCase
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('testfile.txt', $attachment->getName());
         self::assertEquals($this->resource, $attachment->getResource());
+        self::assertEquals('text/json; name="testfile.txt"; charset="utf-16"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"uri":"\/tmp\/attachment test.txt","name":"testfile.txt","contentId":"testid"}',
             $attachment->__toString()
@@ -108,7 +111,7 @@ class ResourceAttachmentTest extends TestCase
         $attachment = new ResourceAttachment($this->resource);
 
         self::assertEquals('text/plain', $attachment->getContentType());
-        self::assertEquals('utf-8', $attachment->getCharset());
+        self::assertEquals(null, $attachment->getCharset());
         self::assertEquals(null, $attachment->getContentId());
         self::assertEquals('QXR0YWNobWVudCBmaWxl', $attachment->getBase64Content());
         self::assertEquals('Attachment file', $attachment->getContent());

--- a/tests/Attachment/ResourceAttachmentTest.php
+++ b/tests/Attachment/ResourceAttachmentTest.php
@@ -58,7 +58,6 @@ class ResourceAttachmentTest extends TestCase
 
         $attachment = new ResourceAttachment($this->resource);
 
-
         self::assertEquals('text/plain', $attachment->getContentType());
         self::assertEquals(null, $attachment->getCharset());
         self::assertEquals(null, $attachment->getContentId());

--- a/tests/Attachment/UrlAttachmentTest.php
+++ b/tests/Attachment/UrlAttachmentTest.php
@@ -59,12 +59,13 @@ class UrlAttachmentTest extends TestCase
         $attachment = new UrlAttachment('http://localhost:8777/test%20test.txt?withquery=1');
 
         self::assertEquals('text/plain', $attachment->getContentType());
-        self::assertEquals('utf-8', $attachment->getCharset());
+        self::assertEquals(null, $attachment->getCharset());
         self::assertEquals(null, $attachment->getContentId());
         self::assertEquals('QXR0YWNobWVudCBmaWxl', $attachment->getBase64Content());
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('test test.txt', $attachment->getName());
         self::assertEquals('http://localhost:8777/test%20test.txt?withquery=1', $attachment->getUrl());
+        self::assertEquals('text/plain; name="test test.txt"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"url":"http:\/\/localhost:8777\/test%20test.txt?withquery=1","name":"test test.txt","contentId":null}',
             $attachment->__toString()
@@ -89,6 +90,7 @@ class UrlAttachmentTest extends TestCase
         self::assertEquals('Attachment file', $attachment->getContent());
         self::assertEquals('testfile.txt', $attachment->getName());
         self::assertEquals('http://localhost:8777/test%20test.txt?withquery=1', $attachment->getUrl());
+        self::assertEquals('text/json; name="testfile.txt"; charset="utf-16"', $attachment->getRfc2822ContentType());
         self::assertEquals(
             '{"url":"http:\/\/localhost:8777\/test%20test.txt?withquery=1","name":"testfile.txt","contentId":"testid"}',
             $attachment->__toString()


### PR DESCRIPTION
Binary attachments should not contain a character set at all, or the
mail client runs the risk of misinterpreting the data. For this reason,
it probably safest for this library to assume there is no predefined
character set and only add it if explicitly asked to.