### PR TITLE
Allow subject to be empty/null on templated emails

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,5 @@
 preset: recommended
 
-linting: true
-
 enabled:
   - align_equals
   - concat_with_spaces

--- a/src/Email.php
+++ b/src/Email.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpEmail;
 
+use PhpEmail\Content\Contracts\TemplatedContent;
+
 class Email
 {
     /**
@@ -32,7 +34,7 @@ class Email
     private $replyTos = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     private $subject;
 
@@ -65,14 +67,16 @@ class Email
      * @throws ValidationException
      */
     public function __construct(
-        string $subject,
+        ?string $subject,
         Content $content,
         Address $from,
         array $toRecipients
     ) {
         Validate::that()
             ->allInstanceOf('toRecipients', $toRecipients, Address::class)
-            ->hasMinLength('subject', $subject, 1)
+            ->using('subject', $subject, function (?string $subject) use ($content) {
+                return $content instanceof TemplatedContent || strlen($subject) >= 1;
+            }, 'Subject must have a length of at least 1 for non-templated emails')
             ->now();
 
         $this->content = $content;
@@ -231,9 +235,9 @@ class Email
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSubject(): string
+    public function getSubject(): ?string
     {
         return $this->subject;
     }

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -39,6 +39,25 @@ class Validate
     }
 
     /**
+     * A flexible validation supporting a Closure rule.
+     *
+     * @param         $property
+     * @param         $value
+     * @param Closure $validation
+     * @param         $message
+     *
+     * @return $this
+     */
+    public function using($property, $value, Closure $validation, $message)
+    {
+        $this->is($property, function () use ($value, $validation) {
+            return $validation($value);
+        }, $message);
+
+        return $this;
+    }
+
+    /**
      * @param string $property
      * @param mixed  $value
      *

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -8,6 +8,7 @@ use PhpEmail\Address;
 use PhpEmail\Attachment\FileAttachment;
 use PhpEmail\Content\EmptyContent;
 use PhpEmail\Content\SimpleContent;
+use PhpEmail\Content\TemplatedContent;
 use PhpEmail\Email;
 use PhpEmail\Header;
 use PhpEmail\ValidationException;
@@ -43,7 +44,18 @@ class EmailTest extends TestCase
     {
         self::expectException(ValidationException::class);
 
-        new Email('', SimpleContent::text('hello'), new Address('sender@test.com'), ['hello']);
+        new Email('', SimpleContent::text('hello'), new Address('sender@test.com'), ['recipient@test.com']);
+    }
+
+    public function testAllowsEmptySubjectWithTemplates()
+    {
+        $emptySubject = new Email('', new TemplatedContent('test', []), new Address('sender@test.com'), [new Address('recipient@test.com')]);
+
+        self::assertEmpty($emptySubject->getSubject());
+
+        $nullSubject = new Email(null, new TemplatedContent('test', []), new Address('sender@test.com'), [new Address('recipient@test.com')]);
+
+        self::assertNull($nullSubject->getSubject());
     }
 
     /**


### PR DESCRIPTION
Many SaaS providers (at least Postmark, SparkPost and SendGrid) support
using a templated subject. This makes providing an explict subject
optional when using these templated delivery mechanisms. To that end the
library should support not setting that value when using templated
content.